### PR TITLE
Add `--version` flag to show the version number

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,12 +118,12 @@ func main() {
 	dir := flag.String("dir", cwd, "The directory to serve")
 	port := flag.Int("port", defaultPort, "The port number to use")
 	host := flag.String("host", defaultHost, "The host to use")
-	version := flag.String("version", VERSION, "Print the version number")
+	version := flag.Bool("version", false, "Print the version number")
 	flag.Parse()
 
 	// if --version is set, print the version number and exit
-	if *version != "" {
-		fmt.Println(*version)
+	if *version {
+		fmt.Println(VERSION)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,6 +100,9 @@ const (
 	DEFAULT_PORT = 5327
 )
 
+// The version number of the application
+const VERSION = "0.1.0"
+
 // A super simple static file server
 func main() {
 	// Get current working directory
@@ -115,7 +118,14 @@ func main() {
 	dir := flag.String("dir", cwd, "The directory to serve")
 	port := flag.Int("port", defaultPort, "The port number to use")
 	host := flag.String("host", defaultHost, "The host to use")
+	version := flag.String("version", VERSION, "Print the version number")
 	flag.Parse()
+
+	// if --version is set, print the version number and exit
+	if *version != "" {
+		fmt.Println(*version)
+		return
+	}
 
 	// Instantiate the Self Serve
 	Self := NewSelf(*host, *dir, *port)


### PR DESCRIPTION
This pull request adds a new --version flag to the application, allowing users to easily check the version number.