### PR TITLE
Add  support for SPA fallbacks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ Usage:
   self-serve public               # Serve 'public' directory
   self-serve --port 8080          # Use a different port
   self-serve --no-watch           # Disable live-reloading
+  self-serve --spa                # Enable SPA mode (fallback to index.html)
 
 Options:
   -d, --dir <path>      Directory to serve (default: current directory)
@@ -22,6 +23,7 @@ Options:
   -w, --watch           Enable live-reloading on file changes (default: true)
       --no-watch        Disable live-reloading
       --cors <origin>   Enable CORS for a specific origin (default: "*")
+      --spa             Enable SPA mode (fallback to index.html)
 
   -h, --help            Show this help message
   -v, --version         Show version number
@@ -33,7 +35,7 @@ Options:
 export function parse(args: string[]) {
     const flags = parseArgs(args, {
         string: ["dir", "host", "port", "cors"],
-        boolean: ["watch", "help", "version"],
+        boolean: ["watch", "help", "version", "spa"],
         negatable: ["watch"],
         alias: {
             "help": "h",
@@ -49,6 +51,7 @@ export function parse(args: string[]) {
             port: DEFAULT_PORT,
             watch: true,
             cors: "*",
+            spa: false,
         },
     })
 


### PR DESCRIPTION
The core issue is with client-side routing. In a Single-Page Application (SPA), the JavaScript framework handles the navigation. When you click a link to go from `/` to `/about`, the browser's URL changes but the framework intercepts it and just updates the page contents without making a new request.

However, if you are on the `/about` page and press the refresh button, the browser sends a `GET /about` request, which will fail as our server looks for a non-existing `/about.html` and will return a 404.

The solution is to fallback to sending a `index.html` instead of 404 for single-page apps. For regular webpages the regular behaviour should suffice