### PR TITLE
Fix: `debounceTimer`'s return type issue

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -258,7 +258,7 @@ export class Self {
             }
 
             this.watcher = Deno.watchFs(this.dir)
-            let debounceTimer: number | null = null
+            let debounceTimer: ReturnType<typeof setTimeout> | null = null
             let isShuttingDown = false
 
             // Handle graceful shutdown


### PR DESCRIPTION
Update the `debounceTimer` type to use `ReturnType` of `setTimeout` 