### PR TITLE
Add module-level documentation and docstrings

### DIFF
--- a/self-serve.ts
+++ b/self-serve.ts
@@ -1,3 +1,17 @@
+/**
+ * `self-serve` is a simple, zero-dependency static file server for local development
+ * with live-reload, CSS hot-swap, SPA fallback, directory listing, and file-based API routes.
+ *
+ * This is the CLI entrypoint. For programmatic/library usage, see the `./server` export.
+ *
+ * @example
+ * ```sh
+ * deno run --allow-net --allow-read jsr:@shresht7/self-serve
+ * ```
+ *
+ * @module
+ */
+
 // Deno Standard Library
 import { cyan, red, yellow, underline, italic } from "@std/fmt/colors"
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,27 @@
+/**
+ * The core `Self` server implementation, usable as a library
+ * for programmatic control over the server lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { Self } from "jsr:@shresht7/self-serve/server"
+ *
+ * const server = new Self({
+ *     dir: "./public",
+ *     host: "localhost",
+ *     port: 3000,
+ *     watch: true,
+ *     cors: "*",
+ *     spa: false,
+ *     apiDir: "api/",
+ * })
+ *
+ * await server.serve()
+ * ```
+ *
+ * @module
+ */
+
 // Deno Standard Library
 import { join, extname } from "@std/path"
 import { green, gray, cyan, red } from "@std/fmt/colors"

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import * as api from './lib/serverFunctions.ts'
 import * as helpers from './helpers/index.ts'
 
 
+/** Configuration options for the {@link Self} server */
 export interface Config {
     /** The directory to serve files from */
     dir: string
@@ -50,6 +51,16 @@ export interface Config {
     apiDir: string
 }
 
+/**
+ * The core `self-serve` server
+ * 
+ * handles:
+ * - static file serving,
+ * - directory listings,
+ * - live-reload over WebSocket,
+ * - SPA fallback
+ * - file-based API routes.
+ */
 export class Self {
     /** The directory to serve the files from */
     private dir: string


### PR DESCRIPTION
Enhance documentation by adding module-level comments for the CLI entrypoint and core server implementation, along with detailed docstrings for the `Config` and `Self` interfaces. 