### PR TITLE
Add support for showing/hiding dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ self-serve --api api
 | `--cors [origin]`        |       | Enable CORS, optionally specifying an origin.   | `*` (if flag is present) |
 | `--spa`                  |       | Enable SPA mode (fallback to `index.html`).     |                          |
 | `--api <path>`           |       | Enable API routes from the specified directory. | `api/`                   |
+| `--show-dotfiles`        |       | Show dotfiles in directory listings.            | `false`                  |
 | `--help`                 | `-h`  | Show the help message.                          |                          |
 | `--version`              | `-v`  | Print the application version.                  |                          |
 
@@ -120,8 +121,8 @@ self-serve --api api
 - Images and JavaScript files get a `Cache-Control: public, max-age=0, must-revalidate` header; other file types have no explicit caching directive.
 - Path-traversal attempts (e.g. `../../etc/passwd`) and null-byte injection are blocked by resolving and comparing real paths before serving.
 
-> [!CAUTION]
-> Dotfiles (e.g. `.env`, `.git/`) are **not** hidden, be mindful of what directory you point `self-serve` at. I should probably add a way to hide sensitive files, but for now, just be careful.
+> [!NOTE]
+> dotfiles (like `.env`) are **hidden** by default in directory listings. Use the `--show-dotfiles` flag to reveal them.
 
 **Known limitations**, compared to a production-grade static file server such as [`@std/http/file-server`](https://jsr.io/@std/http/doc/file-server):
 - No `ETag` / `If-Modified-Since` conditional-request support.

--- a/self-serve.ts
+++ b/self-serve.ts
@@ -46,6 +46,7 @@ async function main() {
         host: args.host,
         port: args.port,
         watch: args.watch,
+        showDotfiles: args["show-dotfiles"],
         cors: args.cors,
         spa: args.spa,
         apiDir: args.api,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,17 +20,18 @@ Usage:
   self-serve --api api            # Enable API routes from the 'api' directory
 
 Options:
-  -d, --dir <path>      Directory to serve (default: current directory)
-  -a, --host <address>  Host address to listen on (default: "localhost")
-  -p, --port <number>   Port to listen on (default: 5327)
-  -w, --watch           Enable live-reloading on file changes (default: true)
-      --no-watch        Disable live-reloading
-      --cors <origin>   Enable CORS for a specific origin (default: "*")
-      --spa             Enable SPA mode (fallback to index.html)
-      --api <path>      Enable API routes from the specified directory (default: "api/")
+  -d, --dir <path>          Directory to serve (default: current directory)
+  -a, --host <address>      Host address to listen on (default: "localhost")
+  -p, --port <number>       Port to listen on (default: 5327)
+  -w, --watch               Enable live-reloading on file changes (default: true)
+      --no-watch            Disable live-reloading
+      --cors <origin>       Enable CORS for a specific origin (default: "*")
+      --spa                 Enable SPA mode (fallback to index.html)
+      --api <path>          Enable API routes from the specified directory (default: "api/")
+      --show-dotfiles       Show dotfiles (e.g. .env) in directory listings (default: false)
 
-  -h, --help            Show this help message
-  -v, --version         Show version number
+  -h, --help                Show this help message
+  -v, --version             Show version number
 `
 
 
@@ -39,7 +40,7 @@ Options:
 export function parse(args: string[]) {
     const flags = parseArgs(args, {
         string: ["dir", "host", "port", "cors", "api"],
-        boolean: ["watch", "help", "version", "spa"],
+        boolean: ["watch", "help", "version", "spa", "show-dotfiles"],
         negatable: ["watch"],
         alias: {
             "help": "h",
@@ -54,6 +55,7 @@ export function parse(args: string[]) {
             host: DEFAULT_HOST,
             port: DEFAULT_PORT,
             watch: true,
+            "show-dotfiles": false,
             cors: "*",
             spa: false,
             api: "api/",

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,8 @@ export interface Config {
     spa: boolean
     /** Path to the server-actions api directory */
     apiDir: string
+    /** Whether to show dotfiles in directory listings */
+    showDotfiles?: boolean
 }
 
 /**
@@ -74,6 +76,8 @@ export class Self {
     private cors: string
     /** Whether to enable SPA fallback routing */
     private spa: boolean
+    /** Whether to show dotfiles in directory listings */
+    private showDotfiles: boolean
     /** Path to the server-actions api directory */
     private apiDir: string
     /** File-System Watcher for hot-reloading */
@@ -96,6 +100,7 @@ export class Self {
         this.liveReload = cfg.watch
         this.cors = cfg.cors
         this.spa = cfg.spa
+        this.showDotfiles = cfg.showDotfiles ?? false
         this.apiDir = cfg.apiDir
         this.setupShutdownListener()
     }
@@ -220,7 +225,7 @@ export class Self {
             return await this.serveFile(indexPath)
         } catch (error) {
             if (error instanceof Deno.errors.NotFound) {
-                const dirList = await template.generateDirectoryListingPage(pathName, path)
+                const dirList = await template.generateDirectoryListingPage(pathName, path, this.showDotfiles)
                 return new Response(dirList, { headers: { 'Content-Type': 'text/html; charset=utf-8' } })
             }
             throw error

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,6 +171,17 @@ export class Self {
         const errResponse = await this.checkPath(pathName, resolvedPath, this.dir)
         if (errResponse) { return errResponse }
 
+        // Block access to dotfiles if not explicitly enabled
+        if (!this.showDotfiles) {
+            const segments = decodedPathName.split('/').filter(s => s.length > 0)
+            if (segments.some(s => s.startsWith('.'))) {
+                return new Response(template.generateNotFoundPage(pathName), {
+                    status: 404,
+                    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+                })
+            }
+        }
+
         try {
             const fileInfo = await Deno.stat(resolvedPath)
             if (fileInfo.isDirectory) {

--- a/src/templates/directoryList.ts
+++ b/src/templates/directoryList.ts
@@ -1,5 +1,5 @@
 /** Generates the HTML for a directory listing page */
-export async function generateDirectoryListingPage(pathName: string, resolvedPath: string): Promise<string> {
+export async function generateDirectoryListingPage(pathName: string, resolvedPath: string, showDotfiles = false): Promise<string> {
     let fileList = ''
     const entries = []
     for await (const entry of Deno.readDir(resolvedPath)) {
@@ -13,6 +13,7 @@ export async function generateDirectoryListingPage(pathName: string, resolvedPat
     })
 
     for (const entry of entries) {
+        if (!showDotfiles && entry.name.startsWith('.')) continue
         const slash = entry.isDirectory ? '/' : ''
         const href = `${pathName.endsWith('/') ? '' : pathName + '/'}${entry.name}${slash}`
         fileList += `<li><a href="${href}">${entry.name}${slash}</a></li>`


### PR DESCRIPTION
Implement functionality to hide dotfiles in directory listings by default, with an option to reveal them using the `--show-dotfiles` flag. Block access to dotfiles unless explicitly enabled.

Update the README to reflect these changes.

Fixes #27